### PR TITLE
New syntax for picardFold

### DIFF
--- a/0_WGSPipeline/0_DicIndex.sh
+++ b/0_WGSPipeline/0_DicIndex.sh
@@ -22,7 +22,7 @@ cd $bwaFold
 module unload openjdk/1.8.0_202
 module load openjdk/1.8.0_60
 cd $picardFold
-java -Xms1g -Xmx3g -jar picard.jar CreateSequenceDictionary R=$myDictPath/$dict.fasta O=$myDictPath/$dict.dict
+java -Xms1g -Xmx3g -jar picard.jar CreateSequenceDictionary -R $myDictPath/$dict.fasta -O $myDictPath/$dict.dict
 
 cd $samFold
 ./samtools faidx $myDictPath/$dict.fasta


### PR DESCRIPTION
According to warning message and https://github.com/broadinstitute/picard/wiki/Command-Line-Syntax-Transition-For-Users-(Pre-Transition)

New parameter syntax is supported since version 2.23.3 of picardfold https://github.com/broadinstitute/picard/releases/tag/2.23.3 (July 2020) and the old one is still working (this a nag message). So this change is optional ATM and can be hold back until future changes.