### PR TITLE
Patch for non existing indels field in A2_Lists2Genes.m

### DIFF
--- a/1_Detection/A2_Lists2Genes.m
+++ b/1_Detection/A2_Lists2Genes.m
@@ -169,7 +169,9 @@ if ismember(IndataType,["Cdist","Adist","denovo","indel"])
     C      = {CNPSummary(:).C}';
     Adist  = {CNPSummary(:).Adist}';
     denovo = {CNPSummary(:).denovo}';
-    indel  = {CNPSummary(:).indel}';
+    if isfield(CNPSummary,'indel') % just if indel fields exists, otherwise ignore
+        indel  = {CNPSummary(:).indel}';
+    end
     rep    = {CNPSummary(:).Sample};
     ORI    = {CNPSummary(:).ORI_Crossing};
 


### PR DESCRIPTION
The `indels` field is just loaded if it exists in the input file.